### PR TITLE
Fixed encoding problem

### DIFF
--- a/cloudapp/src/app/models/external-link-attributes.ts
+++ b/cloudapp/src/app/models/external-link-attributes.ts
@@ -20,7 +20,7 @@ export class  ExternalLinkAttributesImpl implements  ExternalLinkAttributes{
     }
 
     public getEncodedTitle():string {
-       return encodeURI(this.title);
+       return encodeURIComponent(this.title);
     }
 
     public toString(): string {


### PR DESCRIPTION
It fixed encoding problem for ' #Charlottesville : white supremacy, populism, and resistance ' title for example.