### PR TITLE
Error handling in external localization service

### DIFF
--- a/cloudapp/src/app/external-localization/external-localization.service.ts
+++ b/cloudapp/src/app/external-localization/external-localization.service.ts
@@ -12,7 +12,6 @@ constructor(private restService: CloudAppRestService){
 }
 
     externalLinkAttributes$ = (entities: Entity[]) =>{
-        console.log('entities', entities)
         let calls = entities
             .filter(entity => [EntityType.BORROWING_REQUEST].includes(entity.type) && !!entity.link)
             .map(entity => {


### PR DESCRIPTION
Hi. Really neat app! I just have a small suggestion in the external localization service-
* Sometimes the link in the borrowing request entity is empty. This can happen if the request is not associated with a user. I'm not sure if this is correct behavior, but in any case I think we can only handle requests with a link
* I've moved the error handling into the `getRequestFromAlma` method so that we get back results if some of them fail
* I've also noticed that the link for requests who's user name has a space is wrong. That's a bug on the Alma side, but in the meantime I've added handling here. Not sure if this is relevant in your environment, but it may be in others.

Looking forward to having your app published. Thanks!